### PR TITLE
Fix git fetching new tags

### DIFF
--- a/pygrader/student_repos.py
+++ b/pygrader/student_repos.py
@@ -17,14 +17,14 @@ def clone_repo(git_path, tag, student_repo_path):
         )
 
         # Fetch
-        cmd = ["git", "fetch"]
+        cmd = ["git", "fetch", "--tags", "-f"]
         p = subprocess.run(cmd, cwd=student_repo_path)
         if p.returncode:
             print_color(TermColors.RED, "git fetch failed")
             return False
 
         # Checkout tag
-        cmd = ["git", "checkout", "tags/" + tag]
+        cmd = ["git", "checkout", "tags/" + tag, "-f"]
         p = subprocess.run(cmd, cwd=student_repo_path)
         if p.returncode:
             print_color(TermColors.RED, "git checkout of tag failed")


### PR DESCRIPTION
Added a bunch of flags to the fetch and checkout commands. First, we need to fetch the tags (`--tags`) and we need to force it (`-f`) in case there is a conflicting tag. I also forced the git checkout to the tag incase files have been changed in the repo preventing the `git checkout` to work.